### PR TITLE
Add transformations to ingestion.new

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 22.0.3
+elixir 1.10.4-otp-22

--- a/lib/smart_city/ingestion.ex
+++ b/lib/smart_city/ingestion.ex
@@ -70,10 +70,11 @@ defmodule SmartCity.Ingestion do
     |> new()
   end
 
-  def new(%{id: _, targetDataset: _, sourceFormat: type, schema: schema, extractSteps: extractSteps} = msg) do
+  def new(%{id: _, targetDataset: _, sourceFormat: type, schema: schema, extractSteps: extractSteps, transformations: transformations} = msg) do
     msg
     |> Map.put(:schema, Helpers.to_atom_keys(schema))
     |> Map.put(:extractSteps, Helpers.to_atom_keys(extractSteps))
+    |> Map.put(:transformations, Enum.map(transformations, &Transformation.new/1))
     |> Map.replace!(:sourceFormat, Helpers.mime_type(type))
     |> create()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.0.5",
+      version: "5.0.6",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/ingestion_test.exs
+++ b/test/smart_city/ingestion_test.exs
@@ -35,7 +35,8 @@ defmodule SmartCity.IngestionTest do
           targetDataset: "dataset",
           sourceFormat: "gtfs",
           extractSteps: [],
-          schema: []
+          schema: [],
+          transformations: []
         })
 
       assert actual.allow_duplicates == true
@@ -73,7 +74,8 @@ defmodule SmartCity.IngestionTest do
           sourceFormat: "gtfs",
           extractSteps: [],
           schema: [],
-          is_a_good_struct: "no"
+          is_a_good_struct: "no",
+          transformations: []
         })
 
       assert actual.targetDataset == "dataset"
@@ -89,14 +91,15 @@ defmodule SmartCity.IngestionTest do
           targetDataset: "dataset",
           sourceFormat: "gtfs",
           extractSteps: [],
-          schema: []
+          schema: [],
+          transformations: []
         })
 
       assert Map.get(actual, field) == default
 
       where(
-        field: [:schema, :cadence, :extractSteps, :allow_duplicates],
-        default: [[], "never", [], true]
+        field: [:schema, :cadence, :extractSteps, :allow_duplicates, :transformations],
+        default: [[], "never", [], true, []]
       )
     end
 
@@ -107,7 +110,8 @@ defmodule SmartCity.IngestionTest do
           targetDataset: "dataset",
           sourceFormat: extension,
           extractSteps: [],
-          schema: []
+          schema: [],
+          transformations: []
         })
 
       assert Map.get(actual, :sourceFormat) == mime_type
@@ -152,7 +156,8 @@ defmodule SmartCity.IngestionTest do
                 %{"name" => "deep"}
               ]
             }
-          ]
+          ],
+          "transformations" => []
         })
 
       assert List.first(actual.schema) == %{
@@ -177,7 +182,8 @@ defmodule SmartCity.IngestionTest do
                 %{"name" => "deep"}
               ]
             }
-          ]
+          ],
+          transformations: []
         })
 
       assert List.first(actual.schema) == %{


### PR DESCRIPTION
Makes sure that new ingestions also have struct validated transformations.

In addition to unit tests, tested locally with alchemist for confirmation.

Previous to this, the "transformation" field looked like 

```
%{
      "__brook_struct__" => "Elixir.SmartCity.Ingestion.Transformation",
      "parameters" => %{
        "field" => "count",
        "sourceType" => "integer",
        "targetType" => "string"
      },
      "type" => "conversion"
    },
```

Now they look like proper transformations by the time they're pulled in from brook:

```
%SmartCity.Ingestion.Transformation{
      parameters: %{
        regex: "^([0-9])",
        sourceField: "thing",
        targetField: "number"
      },
      type: "regex_extract"
    }
```