### PR TITLE
Making extraction id fields optional for backwards compatibility

### DIFF
--- a/lib/smart_city/data.ex
+++ b/lib/smart_city/data.ex
@@ -47,7 +47,7 @@ defmodule SmartCity.Data do
   @type payload :: String.t()
 
   @derive Jason.Encoder
-  @enforce_keys [:dataset_id, :ingestion_id, :extraction_start_time, :payload, :_metadata, :operational]
+  @enforce_keys [:dataset_id, :payload, :_metadata, :operational]
   defstruct version: "0.1",
             _metadata: %{org: nil, name: nil, stream: false},
             dataset_id: nil,
@@ -121,6 +121,23 @@ defmodule SmartCity.Data do
     {:ok, struct}
   rescue
     e -> {:error, e}
+  end
+
+  def new(%{
+      dataset_id: dataset_id,
+      operational: operational,
+      payload: payload,
+      _metadata: metadata
+  }) do
+    %{
+      dataset_id: dataset_id,
+      operational: operational,
+      payload: payload,
+      _metadata: metadata,
+      ingestion_id: nil,
+      extraction_start_time: nil
+    }
+    |> new()
   end
 
   def new(msg) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.2.0",
+      version: "5.2.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/data_test.exs
+++ b/test/smart_city/data_test.exs
@@ -104,6 +104,39 @@ defmodule SmartCity.DataTest do
 
       assert expected == actual.operational
     end
+
+    test "does not require ingestion_id and extraction_start_time" do
+      map =  %{
+        _metadata: %{
+          name: "stuff",
+          org: "whatever",
+          stream: true
+        },
+        dataset_id: "abc",
+        operational: %{
+          timing: [
+            %{
+              app: "reaper",
+              end_time: 10,
+              label: "sus",
+              start_time: 5
+            }
+          ]
+        },
+        payload: "whatever"
+      }
+
+      json = Jason.encode!(map)
+
+      {:ok, data_from_json} = Data.new(json)
+      assert data_from_json.ingestion_id == nil
+      assert data_from_json.extraction_start_time == nil
+      {:ok, data_from_map} = Data.new(map)
+      assert data_from_map.ingestion_id == nil
+      assert data_from_map.extraction_start_time == nil
+      assert Data.new(json) == Data.new(map)
+    end
+
   end
 
   describe "encode" do


### PR DESCRIPTION
Updating the data struct to be backwards compatible with messages which don't have an ingestion_id or extraction_start_time. This saves us from introducing a breaking change and having to do manual deploy steps to account for processing old messages. If we want to make these fields required we can update them later.