### PR TITLE
Introduce to_string_keys

### DIFF
--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -52,7 +52,7 @@ defmodule SmartCity.Helpers do
       iex> SmartCity.Helpers.to_string_keys(%{abc: 123})
       %{"abc" => 123}
 
-      iex> SmartCity.Helpers.to_string_keys(%{a: %{b: => "c"}})
+      iex> SmartCity.Helpers.to_string_keys(%{a: %{b: "c"}})
       %{"a" => %{"b" => "c"}}
 
       iex> SmartCity.Helpers.to_string_keys(%{a: [%{b: "c"}]})

--- a/lib/smart_city/helpers.ex
+++ b/lib/smart_city/helpers.ex
@@ -8,7 +8,7 @@ defmodule SmartCity.Helpers do
 
   @doc """
   Convert a map with string keys to one with atom keys. Will convert keys nested in a sub-map or a
-  map that is part of a list. Ignores atom keys.
+  map that is part of a list. Ignores existing atom keys.
 
   ## Examples
 
@@ -42,6 +42,43 @@ defmodule SmartCity.Helpers do
   def safe_string_to_atom(string) when is_binary(string), do: String.to_atom(string)
   def safe_string_to_atom(atom) when is_atom(atom), do: atom
   def safe_string_to_atom(value), do: value
+
+  @doc """
+  Convert a map with atom keys to one with string keys. Will convert keys nested in a sub-map or a
+  map that is part of a list. Ignores existing string keys.
+
+  ## Examples
+
+      iex> SmartCity.Helpers.to_string_keys(%{abc: 123})
+      %{"abc" => 123}
+
+      iex> SmartCity.Helpers.to_string_keys(%{a: %{b: => "c"}})
+      %{"a" => %{"b" => "c"}}
+
+      iex> SmartCity.Helpers.to_string_keys(%{a: [%{b: "c"}]})
+      %{"a" => [%{"b" => "c"}]}
+  """
+  @spec to_string_keys(map()) :: map()
+  def to_string_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, val} when is_map(val) or is_list(val) ->
+        {safe_atom_to_string(key), to_string_keys(val)}
+
+      {key, val} when is_atom(key) ->
+        {safe_atom_to_string(key), val}
+
+      keyval ->
+        keyval
+    end)
+  end
+
+  def to_string_keys(list) when is_list(list), do: Enum.map(list, &to_string_keys/1)
+
+  def to_string_keys(value), do: value
+
+  def safe_atom_to_string(atom) when is_atom(atom), do: Atom.to_string(atom)
+  def safe_atom_to_string(string) when is_binary(string), do: string
+  def safe_atom_to_string(value), do: value
 
   @doc """
   Standardize file type definitions by deferring to the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.2.5",
+      version: "5.2.6",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/helpers_test.exs
+++ b/test/smart_city/helpers_test.exs
@@ -59,6 +59,65 @@ defmodule SmartCity.HelpersTest do
     end
   end
 
+  describe "to_string_keys/1" do
+    test "converts top level atom keys to strings" do
+      assert Helpers.to_string_keys(%{foo: "bar"}) == %{"foo" => "bar"}
+    end
+
+    test "converts top level keys in a list to strings" do
+      input = %{list: [%{foo: "bar"}, %{abc: "xyz"}]}
+      expected = %{"list" => [%{"foo" => "bar"}, %{"abc" => "xyz"}]}
+
+      assert Helpers.to_string_keys(input) == expected
+    end
+
+    test "converts nested keys to strings" do
+      input = %{foo: %{bar: "baz"}}
+      expected = %{"foo" => %{"bar" => "baz"}}
+
+      assert Helpers.to_string_keys(input) == expected
+    end
+
+    test "converts nested keys in a nested list" do
+      input = %{
+        foo: %{
+          bar: [%{baz: [%{abc: 123}]}]
+        }
+      }
+
+      expected = %{
+        "foo" => %{
+          "bar" => [%{"baz" => [%{"abc" => 123}]}]
+        }
+      }
+
+      assert Helpers.to_string_keys(input) == expected
+    end
+
+    test "handles a map with string keys" do
+      input = %{"foo" => 1}
+      assert Helpers.to_string_keys(input) == input
+    end
+
+    test "handles a map with string keys that has nested atom keys" do
+      input = %{"foo" => 1, "bar" => %{baz: "derp"}}
+      expected = %{"foo" => 1, "bar" => %{"baz" => "derp"}}
+      assert Helpers.to_string_keys(input) == expected
+    end
+
+    test "handles a map with string keys that has a list of objects with atom keys" do
+      input = %{"foo" => 1, "bar" => [%{baz: "derp"}]}
+      expected = %{"foo" => 1, "bar" => [%{"baz" => "derp"}]}
+      assert Helpers.to_string_keys(input) == expected
+    end
+
+    test "handles a list of maps with nested atom keys" do
+      input = [%{"foo" => 1, "bar" => [%{baz: "derp"}]}]
+      expected = [%{"foo" => 1, "bar" => [%{"baz" => "derp"}]}]
+      assert Helpers.to_string_keys(input) == expected
+    end
+  end
+
   describe "mime_type/1" do
     test "converts file extension to recognized type" do
       assert "application/json" == Helpers.mime_type("json")


### PR DESCRIPTION
## Description:

- Adds `Helpers.to_string_keys`
  - Does the inverse of `Helpers.to_atom_keys`
  -  Equal amount of testing as `Helpers.to_atom_keys` as well

## Reminders:

- [ ] ~~If adding a new smart city data module, does it have a relevant test~~
  - [ ] ~~If a struct was added to an existing struct, was the parent `.new` method updated to convert keys to atoms~~
- [ ] ~~If updating an existing module's type, was it's @moduledoc updated as well~~
