### PR TITLE
Bump version number

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.2.7",
+      version: "5.2.8",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Previously tried to remove and replace a broken release under 5.2.7. This didn't work, so we're rolling forward instead.
