### PR TITLE
added ingestion_field_selector to schema auto-generation

### DIFF
--- a/lib/smart_city/schema_generator.ex
+++ b/lib/smart_city/schema_generator.ex
@@ -105,7 +105,8 @@ defmodule SmartCity.SchemaGenerator do
       "masked" => "N/A",
       "name" => name,
       "pii" => "None",
-      "type" => type
+      "type" => type,
+      "ingestion_field_selector" => name
     }
   end
 end

--- a/lib/smart_city/schema_generator.ex
+++ b/lib/smart_city/schema_generator.ex
@@ -64,7 +64,8 @@ defmodule SmartCity.SchemaGenerator do
     %{
       "name" => name,
       "type" => type,
-      "itemType" => "string"
+      "itemType" => "string",
+      "ingestion_field_selector" => name
     }
     |> Map.merge(@base_schema)
   end
@@ -73,7 +74,8 @@ defmodule SmartCity.SchemaGenerator do
     %{
       "name" => name,
       "type" => type,
-      "itemType" => item_type
+      "itemType" => item_type,
+      "ingestion_field_selector" => name
     }
     |> Map.merge(@base_schema)
   end
@@ -83,7 +85,8 @@ defmodule SmartCity.SchemaGenerator do
       "name" => name,
       "type" => type,
       "itemType" => item_type,
-      "subSchema" => schema
+      "subSchema" => schema,
+      "ingestion_field_selector" => name
     }
     |> Map.merge(@base_schema)
   end
@@ -92,7 +95,8 @@ defmodule SmartCity.SchemaGenerator do
     %{
       "name" => name,
       "type" => type,
-      "subSchema" => schema
+      "subSchema" => schema,
+      "ingestion_field_selector" => name
     }
     |> Map.merge(@base_schema)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.2.9",
+      version: "5.3.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.2.8",
+      version: "5.2.9",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/schema_generator_test.exs
+++ b/test/smart_city/schema_generator_test.exs
@@ -21,7 +21,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "masked" => "N/A",
           "name" => "key_field",
           "pii" => "None",
-          "type" => "string"
+          "type" => "string",
+          "ingestion_field_selector" => "key_field"
         }
       ]
 
@@ -46,6 +47,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "map_field",
           "pii" => "None",
           "type" => "map",
+          "ingestion_field_selector" => "map_field",
           "subSchema" => [
             %{
               "biased" => "No",
@@ -54,7 +56,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "masked" => "N/A",
               "name" => "sub_key_field",
               "pii" => "None",
-              "type" => "string"
+              "type" => "string",
+              "ingestion_field_selector" => "sub_key_field"
             }
           ]
         }
@@ -81,6 +84,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "map_field",
           "pii" => "None",
           "type" => "map",
+          "ingestion_field_selector" => "map_field",
           "subSchema" => [
             %{
               "biased" => "No",
@@ -90,6 +94,7 @@ defmodule SmartCity.SchemaGeneratorTest do
               "name" => "sub_key_map",
               "pii" => "None",
               "type" => "map",
+              "ingestion_field_selector" => "sub_key_map",
               "subSchema" => [
                 %{
                   "biased" => "No",
@@ -98,7 +103,8 @@ defmodule SmartCity.SchemaGeneratorTest do
                   "masked" => "N/A",
                   "name" => "sub_sub_key",
                   "pii" => "None",
-                  "type" => "string"
+                  "type" => "string",
+                  "ingestion_field_selector" => "sub_sub_key"
                 }
               ]
             }
@@ -128,6 +134,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "list",
           "itemType" => "map",
+          "ingestion_field_selector" => "map_field",
           "subSchema" => [
             %{
               "biased" => "No",
@@ -136,7 +143,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "masked" => "N/A",
               "name" => "sub_key_field",
               "pii" => "None",
-              "type" => "string"
+              "type" => "string",
+              "ingestion_field_selector" => "sub_key_field"
             },
             %{
               "biased" => "No",
@@ -145,7 +153,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "masked" => "N/A",
               "name" => "sub_key_field2",
               "pii" => "None",
-              "type" => "string"
+              "type" => "string",
+              "ingestion_field_selector" => "sub_key_field2"
             }
           ]
         }
@@ -172,7 +181,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "list_field",
           "pii" => "None",
           "type" => "list",
-          "itemType" => "string"
+          "itemType" => "string",
+          "ingestion_field_selector" => "list_field"
         }
       ]
 
@@ -198,6 +208,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "list",
           "itemType" => "map",
+          "ingestion_field_selector" => "map_field",
           "subSchema" => [
             %{
               "biased" => "No",
@@ -206,7 +217,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "masked" => "N/A",
               "name" => "sub_key_field",
               "pii" => "None",
-              "type" => "string"
+              "type" => "string",
+              "ingestion_field_selector" => "sub_key_field"
             },
             %{
               "biased" => "No",
@@ -217,6 +229,7 @@ defmodule SmartCity.SchemaGeneratorTest do
               "pii" => "None",
               "type" => "list",
               "itemType" => "map",
+              "ingestion_field_selector" => "sub_map_field",
               "subSchema" => [
                 %{
                   "biased" => "No",
@@ -225,7 +238,8 @@ defmodule SmartCity.SchemaGeneratorTest do
                   "masked" => "N/A",
                   "name" => "sub_sub_key_field",
                   "pii" => "None",
-                  "type" => "string"
+                  "type" => "string",
+                  "ingestion_field_selector" => "sub_sub_key_field"
                 }
               ]
             }
@@ -254,7 +268,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "list_field",
           "pii" => "None",
           "type" => "list",
-          "itemType" => "string"
+          "itemType" => "string",
+          "ingestion_field_selector" => "list_field"
         }
       ]
 
@@ -275,7 +290,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "list_field",
           "pii" => "None",
           "type" => "list",
-          "itemType" => "string"
+          "itemType" => "string",
+          "ingestion_field_selector" => "list_field"
         }
       ]
 
@@ -299,7 +315,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "masked" => "N/A",
           "name" => "key_field",
           "pii" => "None",
-          "type" => type
+          "type" => type,
+          "ingestion_field_selector" => "key_field"
         }
       ]
 


### PR DESCRIPTION
## Reminders:

- [ ] If adding a new smart city data module, does it have a relevant test
  - [ ] If a struct was added to an existing struct, was the parent `.new` method updated to convert keys to atoms
- [ ] If updating an existing module's type, was it's @moduledoc updated as well
