### PR TITLE
added Ingestion Field Sync to auto-generated schema

### DIFF
--- a/lib/smart_city/schema_generator.ex
+++ b/lib/smart_city/schema_generator.ex
@@ -65,7 +65,8 @@ defmodule SmartCity.SchemaGenerator do
       "name" => name,
       "type" => type,
       "itemType" => "string",
-      "ingestion_field_selector" => name
+      "ingestion_field_selector" => name,
+      "ingestion_field_sync" => true
     }
     |> Map.merge(@base_schema)
   end
@@ -75,7 +76,8 @@ defmodule SmartCity.SchemaGenerator do
       "name" => name,
       "type" => type,
       "itemType" => item_type,
-      "ingestion_field_selector" => name
+      "ingestion_field_selector" => name,
+      "ingestion_field_sync" => true
     }
     |> Map.merge(@base_schema)
   end
@@ -86,7 +88,8 @@ defmodule SmartCity.SchemaGenerator do
       "type" => type,
       "itemType" => item_type,
       "subSchema" => schema,
-      "ingestion_field_selector" => name
+      "ingestion_field_selector" => name,
+      "ingestion_field_sync" => true
     }
     |> Map.merge(@base_schema)
   end
@@ -96,7 +99,8 @@ defmodule SmartCity.SchemaGenerator do
       "name" => name,
       "type" => type,
       "subSchema" => schema,
-      "ingestion_field_selector" => name
+      "ingestion_field_selector" => name,
+      "ingestion_field_sync" => true
     }
     |> Map.merge(@base_schema)
   end
@@ -110,7 +114,8 @@ defmodule SmartCity.SchemaGenerator do
       "name" => name,
       "pii" => "None",
       "type" => type,
-      "ingestion_field_selector" => name
+      "ingestion_field_selector" => name,
+      "ingestion_field_sync" => true
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.3.0",
+      version: "5.3.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/schema_generator_test.exs
+++ b/test/smart_city/schema_generator_test.exs
@@ -22,7 +22,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "key_field",
           "pii" => "None",
           "type" => "string",
-          "ingestion_field_selector" => "key_field"
+          "ingestion_field_selector" => "key_field",
+          "ingestion_field_sync" => true
         }
       ]
 
@@ -48,6 +49,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "map",
           "ingestion_field_selector" => "map_field",
+          "ingestion_field_sync" => true,
           "subSchema" => [
             %{
               "biased" => "No",
@@ -57,7 +59,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "name" => "sub_key_field",
               "pii" => "None",
               "type" => "string",
-              "ingestion_field_selector" => "sub_key_field"
+              "ingestion_field_selector" => "sub_key_field",
+              "ingestion_field_sync" => true
             }
           ]
         }
@@ -85,6 +88,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "map",
           "ingestion_field_selector" => "map_field",
+          "ingestion_field_sync" => true,
           "subSchema" => [
             %{
               "biased" => "No",
@@ -95,6 +99,7 @@ defmodule SmartCity.SchemaGeneratorTest do
               "pii" => "None",
               "type" => "map",
               "ingestion_field_selector" => "sub_key_map",
+              "ingestion_field_sync" => true,
               "subSchema" => [
                 %{
                   "biased" => "No",
@@ -104,7 +109,8 @@ defmodule SmartCity.SchemaGeneratorTest do
                   "name" => "sub_sub_key",
                   "pii" => "None",
                   "type" => "string",
-                  "ingestion_field_selector" => "sub_sub_key"
+                  "ingestion_field_selector" => "sub_sub_key",
+                  "ingestion_field_sync" => true
                 }
               ]
             }
@@ -135,6 +141,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "type" => "list",
           "itemType" => "map",
           "ingestion_field_selector" => "map_field",
+          "ingestion_field_sync" => true,
           "subSchema" => [
             %{
               "biased" => "No",
@@ -144,7 +151,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "name" => "sub_key_field",
               "pii" => "None",
               "type" => "string",
-              "ingestion_field_selector" => "sub_key_field"
+              "ingestion_field_selector" => "sub_key_field",
+              "ingestion_field_sync" => true
             },
             %{
               "biased" => "No",
@@ -154,7 +162,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "name" => "sub_key_field2",
               "pii" => "None",
               "type" => "string",
-              "ingestion_field_selector" => "sub_key_field2"
+              "ingestion_field_selector" => "sub_key_field2",
+              "ingestion_field_sync" => true
             }
           ]
         }
@@ -182,7 +191,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "list",
           "itemType" => "string",
-          "ingestion_field_selector" => "list_field"
+          "ingestion_field_selector" => "list_field",
+          "ingestion_field_sync" => true
         }
       ]
 
@@ -209,6 +219,7 @@ defmodule SmartCity.SchemaGeneratorTest do
           "type" => "list",
           "itemType" => "map",
           "ingestion_field_selector" => "map_field",
+          "ingestion_field_sync" => true,
           "subSchema" => [
             %{
               "biased" => "No",
@@ -218,7 +229,8 @@ defmodule SmartCity.SchemaGeneratorTest do
               "name" => "sub_key_field",
               "pii" => "None",
               "type" => "string",
-              "ingestion_field_selector" => "sub_key_field"
+              "ingestion_field_selector" => "sub_key_field",
+              "ingestion_field_sync" => true
             },
             %{
               "biased" => "No",
@@ -230,6 +242,7 @@ defmodule SmartCity.SchemaGeneratorTest do
               "type" => "list",
               "itemType" => "map",
               "ingestion_field_selector" => "sub_map_field",
+              "ingestion_field_sync" => true,
               "subSchema" => [
                 %{
                   "biased" => "No",
@@ -239,7 +252,8 @@ defmodule SmartCity.SchemaGeneratorTest do
                   "name" => "sub_sub_key_field",
                   "pii" => "None",
                   "type" => "string",
-                  "ingestion_field_selector" => "sub_sub_key_field"
+                  "ingestion_field_selector" => "sub_sub_key_field",
+                  "ingestion_field_sync" => true
                 }
               ]
             }
@@ -269,7 +283,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "list",
           "itemType" => "string",
-          "ingestion_field_selector" => "list_field"
+          "ingestion_field_selector" => "list_field",
+          "ingestion_field_sync" => true
         }
       ]
 
@@ -291,7 +306,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "pii" => "None",
           "type" => "list",
           "itemType" => "string",
-          "ingestion_field_selector" => "list_field"
+          "ingestion_field_selector" => "list_field",
+          "ingestion_field_sync" => true
         }
       ]
 
@@ -316,7 +332,8 @@ defmodule SmartCity.SchemaGeneratorTest do
           "name" => "key_field",
           "pii" => "None",
           "type" => type,
-          "ingestion_field_selector" => "key_field"
+          "ingestion_field_selector" => "key_field",
+          "ingestion_field_sync" => true
         }
       ]
 


### PR DESCRIPTION
## Reminders:

- [ ] If adding a new smart city data module, does it have a relevant test
  - [ ] If a struct was added to an existing struct, was the parent `.new` method updated to convert keys to atoms
- [ ] If updating an existing module's type, was it's @moduledoc updated as well
