### PR TITLE
Added backward compatiability for multiple datasets

### DIFF
--- a/lib/smart_city/ingestion.ex
+++ b/lib/smart_city/ingestion.ex
@@ -1,4 +1,6 @@
 defmodule SmartCity.Ingestion do
+  require Logger
+
   alias SmartCity.Helpers
   alias SmartCity.Ingestion.Transformation
 
@@ -90,6 +92,14 @@ defmodule SmartCity.Ingestion do
     |> Map.put(:transformations, Enum.map(transformations, &Transformation.new/1))
     |> Map.replace!(:sourceFormat, Helpers.mime_type(type))
     |> create()
+  end
+
+  def new( %{ targetDataset: targetDataset } = msg )  do
+    Logger.error("Legacy ingestion detected. targetDataset field was used instead of targetDatasets. This field is deprecated to be removed after June 2023.")
+    msg
+    |> Map.put(:targetDatasets, [targetDataset])
+    |> Map.delete(:targetDataset)
+    |> new()
   end
 
   def new(msg) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.4.0",
+      version: "5.4.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/smart_city/ingestion_test.exs
+++ b/test/smart_city/ingestion_test.exs
@@ -57,6 +57,29 @@ defmodule SmartCity.IngestionTest do
       assert actual.transformations == []
     end
 
+    test "can handle deprecated targetDataset field" do
+      actual =
+        Ingestion.new(%{
+          id: "uuid",
+          name: "name",
+          targetDataset: "ds1",
+          sourceFormat: "gtfs",
+          extractSteps: [],
+          schema: [],
+          transformations: []
+        })
+
+      assert actual.allow_duplicates == true
+      assert actual.targetDatasets == ["ds1"]
+      assert actual.name == "name"
+      assert actual.sourceFormat == "application/gtfs+protobuf"
+      assert actual.cadence == "never"
+      assert actual.schema == []
+      assert actual.extractSteps == []
+      assert actual.topLevelSelector == nil
+      assert actual.transformations == []
+    end
+
     test "is idempotent", %{message: msg} do
       actual = msg |> Ingestion.new() |> Ingestion.new()
       assert actual.allow_duplicates == false


### PR DESCRIPTION
## Reminders:

- [ ] If adding a new smart city data module, does it have a relevant test
  - [ ] If a struct was added to an existing struct, was the parent `.new` method updated to convert keys to atoms
- [ ] If updating an existing module's type, was it's @moduledoc updated as well
