### PR TITLE
Added timestamp validation to EventLog struct

### DIFF
--- a/lib/smart_city/event_log.ex
+++ b/lib/smart_city/event_log.ex
@@ -21,7 +21,7 @@ defmodule SmartCity.EventLog do
 
   @type t :: %SmartCity.EventLog{
                title: String.t(),
-               timestamp: String.t(),
+               timestamp: DateTime.t(),
                source: String.t(),
                description: String.t(),
                dataset_id: String.t(),
@@ -65,14 +65,44 @@ defmodule SmartCity.EventLog do
   @spec new(map()) :: SmartCity.EventLog.t()
   def new(
         %{
+          timestamp: "",
+        } = msg
+      ) do
+
+    Map.put(msg, :timestamp, DateTime.to_iso8601(DateTime.utc_now()))
+    |> create()
+  end
+
+  @spec new(map()) :: SmartCity.EventLog.t()
+  def new(
+        %{
           title: _title,
-          timestamp: _timestamp,
+          timestamp: %DateTime{},
           source: _source,
           description: _description,
           dataset_id: _dataset_id
         } = msg
       ) do
-    create(msg)
+
+    Map.put(msg, :timestamp, DateTime.to_iso8601(msg.timestamp))
+    |> create()
+  end
+
+  @spec new(map()) :: SmartCity.EventLog.t()
+  def new(
+        %{
+          title: _title,
+          timestamp: timestamp,
+          source: _source,
+          description: _description,
+          dataset_id: _dataset_id
+        } = msg
+      ) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, _, _} -> create(msg)
+      {:error, _} -> raise ArgumentError, "Invalid timestamp in event_log: #{timestamp}. Expected ISO8601 string format"
+    end
+
   end
 
   def new(msg) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCity.MixProject do
   def project do
     [
       app: :smart_city,
-      version: "5.4.3",
+      version: "5.4.4",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Reminders:

- [ ] If adding a new smart city data module, does it have a relevant test
  - [ ] If a struct was added to an existing struct, was the parent `.new` method updated to convert keys to atoms
- [ ] If updating an existing module's type, was it's @moduledoc updated as well
